### PR TITLE
Rename library to bytebuild. Use Data.Bytes namespace.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,17 @@
-# Revision history for small-bytearray-builder
+# Revision history for bytebuild
+
+Note: Prior to version 0.3.4.0, this library was named
+`small-bytearray-builder`, not `bytebuild`. The library
+`small-bytearray-builder` is now just a compatibility shim
+to ease the migration process.
 
 ## 0.3.4.0 -- 2020-??-??
 
+* Rename the library from `small-bytearray-builder` to `bytebuild`, and
+  move modules from the `Data.ByteArray` namespace to the `Data.Bytes`
+  namespace. This is not considered a breaking change since
+  `small-bytearray-builder` continues to exist as a compatibility shim,
+  reexporting the modules with their old names.
 * Add `wordPaddedDec4`.
 * Add `reversedOnto` and `commitsOntoChunks`.
 * Add `ascii(2|3|4|5|6)`.

--- a/bench/Main.hs
+++ b/bench/Main.hs
@@ -7,8 +7,8 @@ import Gauge (bgroup,bench,whnf)
 import Gauge.Main (defaultMain)
 
 import qualified Arithmetic.Nat as Nat
-import qualified Data.ByteArray.Builder as B
-import qualified Data.ByteArray.Builder.Bounded as U
+import qualified Data.Bytes.Builder as B
+import qualified Data.Bytes.Builder.Bounded as U
 
 import qualified Cell
 import qualified SimpleCsv

--- a/bench/SimpleCsv.hs
+++ b/bench/SimpleCsv.hs
@@ -12,7 +12,7 @@ import Cell (Cell(..))
 import Data.Primitive (SmallArray)
 
 import qualified Data.Foldable as F
-import qualified Data.ByteArray.Builder as B
+import qualified Data.Bytes.Builder as B
 
 encodeRows :: SmallArray (SmallArray Cell) -> B.Builder
 encodeRows = F.foldr

--- a/bytebuild.cabal
+++ b/bytebuild.cabal
@@ -1,5 +1,5 @@
 cabal-version: 2.2
-name: small-bytearray-builder
+name: bytebuild
 version: 0.3.4.0
 synopsis: Serialize to a small byte arrays
 description:
@@ -19,8 +19,8 @@ description:
   of the next chunk. This strategy for building is suitable for most
   CSVs and several line protocols (carbon, InfluxDB, etc.).
   
-homepage: https://github.com/byteverse/small-bytearray-builder
-bug-reports: https://github.com/byteverse/small-bytearray-builder/issues
+homepage: https://github.com/byteverse/bytebuild
+bug-reports: https://github.com/byteverse/bytebuild/issues
 license: BSD-3-Clause
 license-file: LICENSE
 author: Andrew Martin
@@ -36,10 +36,10 @@ flag checked
 
 library
   exposed-modules:
-    Data.ByteArray.Builder
-    Data.ByteArray.Builder.Unsafe
-    Data.ByteArray.Builder.Bounded
-    Data.ByteArray.Builder.Bounded.Unsafe
+    Data.Bytes.Builder
+    Data.Bytes.Builder.Unsafe
+    Data.Bytes.Builder.Bounded
+    Data.Bytes.Builder.Bounded.Unsafe
   reexported-modules:
     Data.Bytes.Chunks
   build-depends:
@@ -72,13 +72,13 @@ test-suite test
   build-depends:
     , QuickCheck >=2.13.1 && <2.14
     , base >=4.12.0.0 && <5
+    , bytebuild
     , byteslice
     , bytestring
     , natural-arithmetic
     , primitive
     , primitive-unlifted >=0.1.2
     , quickcheck-classes >=0.6.4
-    , small-bytearray-builder
     , tasty >=1.2.3 && <1.3
     , tasty-hunit >=0.10.0.2 && <0.11
     , tasty-quickcheck >=0.10.1 && <0.11
@@ -90,10 +90,10 @@ benchmark bench
   type: exitcode-stdio-1.0
   build-depends:
     , base
+    , bytebuild
     , gauge >= 0.2.4
     , natural-arithmetic
     , primitive
-    , small-bytearray-builder
     , text-short
     , byteslice
   ghc-options: -Wall -O2

--- a/common/HexWord64.hs
+++ b/common/HexWord64.hs
@@ -17,7 +17,7 @@ module HexWord64
 
 import GHC.ST (ST(ST))
 import Data.Bits
-import Data.ByteArray.Builder.Bounded.Unsafe (Builder,construct)
+import Data.Bytes.Builder.Bounded.Unsafe (Builder,construct)
 import Data.Primitive
 import Data.Word
 import GHC.Exts

--- a/common/Word16Tree.hs
+++ b/common/Word16Tree.hs
@@ -9,7 +9,7 @@ module Word16Tree
   , expectedSmall
   ) where
 
-import Data.ByteArray.Builder as B
+import Data.Bytes.Builder as B
 import Data.Word (Word16)
 import Data.Primitive (ByteArray)
 import qualified Data.Bytes as Bytes

--- a/src/Data/Bytes/Builder.hs
+++ b/src/Data/Bytes/Builder.hs
@@ -7,7 +7,7 @@
 {-# language ScopedTypeVariables #-}
 {-# language UnboxedTuples #-}
 
-module Data.ByteArray.Builder
+module Data.Bytes.Builder
   ( -- * Bounded Primitives
     Builder
   , fromBounded
@@ -117,13 +117,13 @@ module Data.ByteArray.Builder
 import Control.Exception (SomeException,toException)
 import Control.Monad.ST (ST,runST)
 import Control.Monad.IO.Class (MonadIO,liftIO)
-import Data.ByteArray.Builder.Unsafe (Builder(Builder))
-import Data.ByteArray.Builder.Unsafe (BuilderState(BuilderState),pasteIO)
-import Data.ByteArray.Builder.Unsafe (Commits(Initial,Mutable,Immutable))
-import Data.ByteArray.Builder.Unsafe (reverseCommitsOntoChunks)
-import Data.ByteArray.Builder.Unsafe (commitsOntoChunks)
-import Data.ByteArray.Builder.Unsafe (stringUtf8,cstring)
-import Data.ByteArray.Builder.Unsafe (addCommitsLength,copyReverseCommits)
+import Data.Bytes.Builder.Unsafe (Builder(Builder))
+import Data.Bytes.Builder.Unsafe (BuilderState(BuilderState),pasteIO)
+import Data.Bytes.Builder.Unsafe (Commits(Initial,Mutable,Immutable))
+import Data.Bytes.Builder.Unsafe (reverseCommitsOntoChunks)
+import Data.Bytes.Builder.Unsafe (commitsOntoChunks)
+import Data.Bytes.Builder.Unsafe (stringUtf8,cstring)
+import Data.Bytes.Builder.Unsafe (addCommitsLength,copyReverseCommits)
 import Data.ByteString.Short.Internal (ShortByteString(SBS))
 import Data.Bytes.Chunks (Chunks(ChunksNil))
 import Data.Bytes.Types (Bytes(Bytes),MutableBytes(MutableBytes))
@@ -143,8 +143,8 @@ import GHC.ST (ST(ST))
 
 import qualified Arithmetic.Nat as Nat
 import qualified Arithmetic.Types as Arithmetic
-import qualified Data.ByteArray.Builder.Bounded as Bounded
-import qualified Data.ByteArray.Builder.Bounded.Unsafe as UnsafeBounded
+import qualified Data.Bytes.Builder.Bounded as Bounded
+import qualified Data.Bytes.Builder.Bounded.Unsafe as UnsafeBounded
 import qualified Data.Primitive as PM
 import qualified Data.Text.Short as TS
 import qualified GHC.Exts as Exts
@@ -231,7 +231,7 @@ putMany hint0 g xs cb = do
 putManyError :: SomeException
 {-# noinline putManyError #-}
 putManyError = toException
-  (userError "small-bytearray-builder: putMany implementation error")
+  (userError "bytebuild: putMany implementation error")
 
 -- | Variant of 'putMany' that prefixes each pushed array of chunks
 -- with the number of bytes that the chunks in each batch required.

--- a/src/Data/Bytes/Builder/Bounded.hs
+++ b/src/Data/Bytes/Builder/Bounded.hs
@@ -12,7 +12,7 @@
 
 -- | The functions in this module are explict about the maximum number
 -- of bytes they require.
-module Data.ByteArray.Builder.Bounded
+module Data.Bytes.Builder.Bounded
   ( -- * Builder
     Builder
     -- * Execute
@@ -98,7 +98,7 @@ import Control.Monad.Primitive
 import Control.Monad.ST (ST)
 import Control.Monad.ST.Run (runByteArrayST)
 import Data.Bits
-import Data.ByteArray.Builder.Bounded.Unsafe (Builder(..))
+import Data.Bytes.Builder.Bounded.Unsafe (Builder(..))
 import Data.Char (ord)
 import Data.Primitive
 import Data.Primitive.ByteArray.Offset (MutableByteArrayOffset(..))
@@ -112,7 +112,7 @@ import GHC.Word (Word8(W8#),Word16(W16#),Word32(W32#),Word64(W64#))
 import qualified Arithmetic.Lte as Lte
 import qualified Arithmetic.Nat as Nat
 import qualified Arithmetic.Types as Arithmetic
-import qualified Data.ByteArray.Builder.Bounded.Unsafe as Unsafe
+import qualified Data.Bytes.Builder.Bounded.Unsafe as Unsafe
 import qualified Data.Primitive as PM
 
 -- | Execute the bounded builder. If the size is a constant,

--- a/src/Data/Bytes/Builder/Bounded/Unsafe.hs
+++ b/src/Data/Bytes/Builder/Bounded/Unsafe.hs
@@ -6,7 +6,7 @@
 {-# language ScopedTypeVariables #-}
 {-# language UnboxedTuples #-}
 
-module Data.ByteArray.Builder.Bounded.Unsafe
+module Data.Bytes.Builder.Bounded.Unsafe
   ( -- * Types
     Builder(..)
     -- * Construct

--- a/src/Data/Bytes/Builder/Unsafe.hs
+++ b/src/Data/Bytes/Builder/Unsafe.hs
@@ -6,7 +6,7 @@
 {-# language ScopedTypeVariables #-}
 {-# language UnboxedTuples #-}
 
-module Data.ByteArray.Builder.Unsafe
+module Data.Bytes.Builder.Unsafe
   ( -- * Types
     Builder(..)
   , BuilderState(..)
@@ -24,7 +24,7 @@ module Data.ByteArray.Builder.Unsafe
     -- * Safe Functions
     -- | These functions are actually completely safe, but they are defined
     -- here because they are used by typeclass instances. Import them from
-    -- @Data.ByteArray.Builder@ instead.
+    -- @Data.Bytes.Builder@ instead.
   , stringUtf8
   , cstring
   ) where
@@ -41,8 +41,8 @@ import GHC.Exts (RealWorld,IsString,Int#,State#)
 import GHC.ST (ST(ST))
 import GHC.IO (stToIO)
 
-import qualified Data.ByteArray.Builder.Bounded as Bounded
-import qualified Data.ByteArray.Builder.Bounded.Unsafe as UnsafeBounded
+import qualified Data.Bytes.Builder.Bounded as Bounded
+import qualified Data.Bytes.Builder.Bounded.Unsafe as UnsafeBounded
 import qualified Data.Primitive as PM
 import qualified GHC.Exts as Exts
 

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -7,7 +7,7 @@
 
 import Control.Applicative (liftA2)
 import Control.Monad.ST (runST)
-import Data.ByteArray.Builder
+import Data.Bytes.Builder
 import Data.Bytes.Types (MutableBytes(MutableBytes))
 import Data.Primitive (PrimArray)
 import Data.Word
@@ -21,7 +21,7 @@ import Text.Printf (printf)
 import Test.Tasty.HUnit ((@=?))
 
 import qualified Arithmetic.Nat as Nat
-import qualified Data.ByteArray.Builder.Bounded as Bounded
+import qualified Data.Bytes.Builder.Bounded as Bounded
 import qualified Data.ByteString as ByteString
 import qualified Data.ByteString.Builder as BB
 import qualified Data.ByteString.Lazy.Char8 as LB


### PR DESCRIPTION
Resolves https://github.com/byteverse/small-bytearray-builder/issues/11